### PR TITLE
Added a config plugin that makes this module compatible with the Expo managed workflow

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -6,33 +6,6 @@ const withCarService = (config, { service = '.CarService' } = {}) => {
   return withAndroidManifest(config, async (config) => {
     let mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
 
-    mainApplication['service'] = [
-      {
-        $: {
-          'android:name': service,
-          'android:exported': 'true',
-        },
-        'intent-filter': [
-          {
-            'action': [
-              {
-                $: {
-                  'android:name': 'androidx.car.app.CarAppService',
-                },
-              },
-            ],
-            'category': [
-              {
-                $: {
-                  'android:name': 'androidx.car.app.category.NAVIGATION',
-                },
-              },
-            ],
-          },
-        ],
-      },
-    ];
-
     mainApplication['meta-data'] = [
       {
         $: {

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -40,6 +40,12 @@ const withCarService = (config, { service = '.CarService' } = {}) => {
           'android:value': '1',
         },
       },
+      {
+        $: {
+          'android:name': 'com.google.android.gms.car.application',
+          'android:resource': '@xml/automotive_app_desc',
+        },
+      },
     ];
 
     return config;

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,5 +1,5 @@
 const { withAndroidManifest, AndroidConfig, withDangerousMod } = require('@expo/config-plugins');
-const { writeFileSync } = require('fs');
+const { writeFileSync, mkdirSync } = require('fs');
 const { join } = require('path');
 
 const withCarService = (config, { service = '.CarService' } = {}) => {
@@ -55,16 +55,18 @@ const withAutomotiveAppDesc = (config) => {
   <uses name="template" />
 </automotiveApp>`;
 
-      const filePath = join(
+      const dirPath = join(
         config.modRequest.projectRoot,
         'android',
         'app',
         'src',
         'main',
         'res',
-        'xml',
-        'automotive_app_desc.xml'
+        'xml'
       );
+      mkdirSync(dirPath, { recursive: true }); // This will create the directories if they don't exist
+
+      const filePath = join(dirPath, 'automotive_app_desc.xml');
 
       writeFileSync(filePath, automotiveAppDescXml);
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,80 @@
+const { withAndroidManifest, AndroidConfig, withDangerousMod } = require('@expo/config-plugins');
+const { writeFileSync } = require('fs');
+const { join } = require('path');
+
+const withCarService = (config, { service = '.CarService' } = {}) => {
+  return withAndroidManifest(config, async (config) => {
+    let mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+
+    mainApplication['service'] = [
+      {
+        $: {
+          'android:name': service,
+          'android:exported': 'true',
+        },
+        'intent-filter': [
+          {
+            'action': [
+              {
+                $: {
+                  'android:name': 'androidx.car.app.CarAppService',
+                },
+              },
+            ],
+            'category': [
+              {
+                $: {
+                  'android:name': 'androidx.car.app.category.NAVIGATION',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    mainApplication['meta-data'] = [
+      {
+        $: {
+          'android:name': 'androidx.car.app.minCarApiLevel',
+          'android:value': '1',
+        },
+      },
+    ];
+
+    return config;
+  });
+};
+
+const withAutomotiveAppDesc = (config) => {
+  return withDangerousMod(config, [
+    'android',
+    async (config) => {
+      const automotiveAppDescXml = `<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+  <uses name="template" />
+</automotiveApp>`;
+
+      const filePath = join(
+        config.modRequest.projectRoot,
+        'android',
+        'app',
+        'src',
+        'main',
+        'res',
+        'xml',
+        'automotive_app_desc.xml'
+      );
+
+      writeFileSync(filePath, automotiveAppDescXml);
+
+      return config;
+    },
+  ]);
+};
+
+module.exports = (config) => {
+  config = withCarService(config);
+  config = withAutomotiveAppDesc(config);
+  return config;
+};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "!ios/build",
     "!**/__tests__",
     "!**/__fixtures__",
-    "!**/__mocks__"
+    "!**/__mocks__",
+    "app.plugin.js"
   ],
   "scripts": {
     "test": "jest",
@@ -46,6 +47,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "@expo/config-plugins": "^6.0.1",
     "lodash": "^4.17.20",
     "react-reconciler": "^0.26.1"
   },
@@ -56,10 +58,10 @@
     "@react-native-community/eslint-config": "^3.0.2",
     "@release-it/conventional-changelog": "^5.0.0",
     "@types/jest": "^28.1.2",
+    "@types/lodash": "^4.14.186",
     "@types/react": "~17.0.21",
     "@types/react-native": "0.68.0",
     "@types/react-reconciler": "^0.18.0",
-    "@types/lodash": "^4.14.186",
     "commitlint": "^17.0.2",
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
I've added an expo config plugin, making this module compatible with the expo managed workflow. This does not mean it can be ran within expo go, since it still needs the native code, however you can create an expo dev-client to mimic expo go. 

To use it, all a user has to do is add the following in their app.json:

```{
"expo": {
    "plugins": [
      "react-native-android-auto"
    ]
  }
}
```

After this, they can use the module through javascript, just like in react native bare and the expo ejected workflow.